### PR TITLE
Add SendToPropertyInspector and SendToPlugin code

### DIFF
--- a/Sources/Common/ESDBasePlugin.h
+++ b/Sources/Common/ESDBasePlugin.h
@@ -30,6 +30,8 @@ public:
 	
 	virtual void DeviceDidConnect(const std::string& inDeviceID, const json &inDeviceInfo) = 0;
 	virtual void DeviceDidDisconnect(const std::string& inDeviceID) = 0;
+
+	virtual void SendToPlugin(const std::string& inAction, const std::string& inContext, const json &inPayload, const std::string& inDeviceID) = 0;
 	
 protected:
 	ESDConnectionManager *mConnectionManager = nullptr;

--- a/Sources/Common/ESDConnectionManager.cpp
+++ b/Sources/Common/ESDConnectionManager.cpp
@@ -103,6 +103,10 @@ void ESDConnectionManager::OnMessage(websocketpp::connection_hdl, WebsocketClien
 			{
 				mPlugin->DeviceDidDisconnect(deviceID);
 			}
+			else if (event == kESDSDKEventSendToPlugin)
+			{
+				mPlugin->SendToPlugin(action, context, payload, deviceID);
+			}
 		}
 		catch (...)
 		{
@@ -252,6 +256,19 @@ void ESDConnectionManager::SetState(int inState, const std::string& inContext)
 	jsonObject[kESDSDKCommonContext] = inContext;
 	jsonObject[kESDSDKCommonPayload] = payload;
 	
+	websocketpp::lib::error_code ec;
+	mWebsocket.send(mConnectionHandle, jsonObject.dump(), websocketpp::frame::opcode::text, ec);
+}
+
+void ESDConnectionManager::SendToPropertyInspector(const std::string & inAction, const std::string & inContext, const json & inPayload)
+{
+	json jsonObject;
+
+	jsonObject[kESDSDKCommonEvent] = kESDSDKEventSendToPropertyInspector;
+	jsonObject[kESDSDKCommonContext] = inContext;
+	jsonObject[kESDSDKCommonAction] = inAction;
+	jsonObject[kESDSDKCommonPayload] = inPayload;
+
 	websocketpp::lib::error_code ec;
 	mWebsocket.send(mConnectionHandle, jsonObject.dump(), websocketpp::frame::opcode::text, ec);
 }

--- a/Sources/Common/ESDConnectionManager.h
+++ b/Sources/Common/ESDConnectionManager.h
@@ -44,6 +44,7 @@ public:
 	void ShowOKForContext(const std::string& inContext);
 	void SetSettings(const json &inSettings, const std::string& inContext);
 	void SetState(int inState, const std::string& inContext);
+	void SendToPropertyInspector(const std::string& inAction, const std::string& inContext, const json &inPayload);
 
 private:
 	


### PR DESCRIPTION
Hi,
For my own code, my plugin had to exchange data with the propertyInspector but the right calls were missing.
Not anymore :)